### PR TITLE
Fix a part of bugs

### DIFF
--- a/adoptedStyleSheets.js
+++ b/adoptedStyleSheets.js
@@ -37,6 +37,7 @@
     const constructed = Symbol('constructed');
     const obsolete = Symbol('obsolete');
     const iframe = document.createElement('iframe');
+    const styles = Symbol('Styles');
     const mutationCallback = mutations => {
       mutations.forEach(mutation => {
         const { addedNodes, removedNodes } = mutation;
@@ -70,7 +71,11 @@
       location.body ? location = location.body : null;
       clone[constructed] = location;  
       sheet[node]._adopters.push({ location, clone });
-      location.appendChild(clone);
+      if (!location[styles]) {
+        location[styles] = document.createElement('head');
+        location.appendChild(location[styles]);
+      }
+      location[styles].appendChild(clone);
       return clone;
     };
 

--- a/adoptedStyleSheets.js
+++ b/adoptedStyleSheets.js
@@ -71,11 +71,15 @@
       location.body ? location = location.body : null;
       clone[constructed] = location;  
       sheet[node]._adopters.push({ location, clone });
-      if (!location[styles]) {
-        location[styles] = document.createElement('head');
-        location.appendChild(location[styles]);
+      if (location instanceof ShadowRoot) {
+        if (!location[styles]) {
+          location[styles] = document.createElement('head');
+          location.appendChild(location[styles]);
+        }
+        location[styles].appendChild(clone);
+      } else {
+        location.appendChild(clone);
       }
-      location[styles].appendChild(clone);
       return clone;
     };
 


### PR DESCRIPTION
Changes:

1. Patch methods on CSSStyleSheet to forward changes to all CSSStyleSheet clones. (https://github.com/calebdwilliams/construct-style-sheets/pull/2/commits/58c18bfe496762c6dce26986b61c55d708c6d723)
2. Move inserted styles from ShadowRoot to ShadowRoot>head, this can fix confliction with React. (https://github.com/calebdwilliams/construct-style-sheets/pull/2/commits/fbf463b5730593f07f6a1dcc51991e7327d3a4c5) (https://github.com/calebdwilliams/construct-style-sheets/pull/2/commits/bfef3139793633390d647b0aa3bcb8e10ac0a1dd)
3. Forward past actions on CSSStyleSheets to future cloned nodes to keep consistency. (https://github.com/calebdwilliams/construct-style-sheets/pull/2/commits/9995963b772ec85ddaa6b1bafc724b22c15c6293)

With these 5 commits, my complex usage of ConstructStyleSheets+ShadowRoot+React+JSS is worked with a few styling bugs.