### PR TITLE
ShadowRoot and errors fix

### DIFF
--- a/adoptedStyleSheets.js
+++ b/adoptedStyleSheets.js
@@ -362,7 +362,7 @@
 
   
   // Double check to make sure the browser supports ShadowRoot
-  if (ShadowRoot) {
+  if (typeof ShadowRoot !== 'undefined') {
     // Shadow root of each element should be observed to add styles to all
     // elements added to this root.
     HTMLElement.prototype.attachShadow = function(...args) {


### PR DESCRIPTION
- Aligns `adoptedStyleSheets` setter `TypeErrors` with language from Chrome
- Double checks presence of `ShadowRoot` before modifying `HTMLElement.prototype.attachShadow` or defining `adoptedStyleSheets` on `ShadowRoot.prototype` to fix #20 