### PR TITLE
Move styles adopted before the page is loaded to body properly

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -52,7 +52,7 @@ module.exports = config => {
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
       'test/polyfills.js': ['rollup'],
-      'dist/adoptedStyleSheets.js': ['babel'],
+      'dist/adoptedStyleSheets.js': coverage ? ['babel'] : [],
       'test/polyfill.test.js': ['rollup'],
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import ConstructStyleSheet, {updatePrototype} from './ConstructStyleSheet';
 import {initAdoptedStyleSheets, initPolyfill} from './init';
 import {OldCSSStyleSheet} from './shared';
+import {isDocumentLoading} from './utils';
 
 updatePrototype(OldCSSStyleSheet.prototype);
 
@@ -8,7 +9,7 @@ window.CSSStyleSheet = ConstructStyleSheet;
 
 initAdoptedStyleSheets();
 
-if (document.readyState === 'loading') {
+if (isDocumentLoading()) {
   document.addEventListener('DOMContentLoaded', initPolyfill);
 } else {
   initPolyfill();

--- a/src/shared.js
+++ b/src/shared.js
@@ -7,6 +7,10 @@ export const hasShadyCss =
 // that need to be moved to the iframe
 export const deferredStyleSheets = [];
 
+// Style elements adopted by document that should be moved
+// to document.body when the document is fully loaded.
+export const deferredDocumentStyleElements = [];
+
 // Adopted stylesheets of specific location (ShadowRoot or Document).
 export const adoptedSheetsRegistry = new WeakMap();
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,8 +7,8 @@ export function instanceOfStyleSheet(instance) {
   );
 }
 
-export function checkAndPrepare(sheets, location) {
-  const locationType = location.tagName ? 'Document' : 'ShadowRoot';
+export function checkAndPrepare(sheets, container) {
+  const locationType = container === document ? 'Document' : 'ShadowRoot';
 
   if (!Array.isArray(sheets)) {
     throw new TypeError(
@@ -25,7 +25,19 @@ export function checkAndPrepare(sheets, location) {
   const uniqueSheets = sheets.filter(
     (value, index) => sheets.indexOf(value) === index,
   );
-  adoptedSheetsRegistry.set(location, uniqueSheets);
+  adoptedSheetsRegistry.set(container, uniqueSheets);
 
   return uniqueSheets;
+}
+
+export function isDocumentLoading() {
+  return document.readyState === 'loading';
+}
+
+export function getAdoptedStyleSheet(location) {
+  return adoptedSheetsRegistry.get(
+    location.parentNode === document.documentElement
+      ? document
+      : location,
+  );
 }


### PR DESCRIPTION
This PR addresses #31 / `TODO` from #32 and implements moving styles adopted before the document is loaded to the `body` after loading is completed.

Also, a couple of improvements are added.