### PR TITLE
Allow overriding the CSSStyleSheet prototype methods

### DIFF
--- a/src/ConstructStyleSheet.js
+++ b/src/ConstructStyleSheet.js
@@ -21,9 +21,11 @@ const cssStyleSheetMethods = [
 const cssStyleSheetNewMethods = ['replace', 'replaceSync'];
 
 export function updatePrototype(proto) {
-  for (let i = 0, len = cssStyleSheetNewMethods.length; i < len; i++) {
-    proto[cssStyleSheetNewMethods[i]] = ConstructStyleSheet.prototype[cssStyleSheetNewMethods[i]];
-  }
+  cssStyleSheetNewMethods.forEach(methodKey => {
+    proto[methodKey] = function () {
+      return ConstructStyleSheet.prototype[methodKey].apply(this, arguments);
+    }
+  });
 
   // ForEach it because we need to preserve "methodKey" in the created function
   cssStyleSheetMethods.forEach(methodKey => {

--- a/test/polyfill.test.js
+++ b/test/polyfill.test.js
@@ -30,6 +30,16 @@ describe('Constructible Style Sheets polyfill', () => {
       expect(sheet instanceof CSSStyleSheet).toBeTruthy();
     });
 
+    it('allows overriding the CSSStyleSheet prototype methods', () => {
+      const css = '* { color: tomato; }';
+      const replaceSyncSpy = spyOn(CSSStyleSheet.prototype, 'replaceSync');
+      sheet.replaceSync(css);
+
+      expect(replaceSyncSpy).toHaveBeenCalledWith(css);
+
+      replaceSyncSpy.and.callThrough();
+    });
+
     describe('replace', () => {
       let result;
 


### PR DESCRIPTION
This PR fixes an issue when you are unable to override the method on `CSSStyleSheet` prototype. It is essential for testing and could also be useful for some other cases.

```javascript
const sheet = new CSSStyleSheet();

const oldReplaceSync = CSSStyleSheet.prototype.replaceSync;
CSSStyleSheet.prototype.replaceSync = function (...args) {
  console.log('replaceSync is overridden');
  oldReplaceSync.apply(this, args);
}

sheet.replaceSync(`* { color: tomato; }`); // -> replaceSync is overridden
```