### PR TITLE
fix: ensure referential integrity, match chromes behavior

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,12 +7,14 @@ export function checkAndPrepare(sheets, container) {
   const locationType = container === document ? 'Document' : 'ShadowRoot';
 
   if (!Array.isArray(sheets)) {
+    // document.adoptedStyleSheets = new CSSStyleSheet();
     throw new TypeError(
       `Failed to set the 'adoptedStyleSheets' property on ${locationType}: Iterator getter is not callable.`,
     );
   }
 
   if (!sheets.every(instanceOfStyleSheet)) {
+    // document.adoptedStyleSheets = [document.styleSheets[0]];
     throw new TypeError(
       `Failed to set the 'adoptedStyleSheets' property on ${locationType}: Failed to convert value to 'CSSStyleSheet'`,
     );

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import {adoptedSheetsRegistry} from './shared';
 import {instanceOfStyleSheet} from './ConstructStyleSheet';
 
-const importPattern = /@import\surl(.*?);/gi;
+const importPattern = /@import/;
 
 export function checkAndPrepare(sheets, container) {
   const locationType = container === document ? 'Document' : 'ShadowRoot';
@@ -40,8 +40,8 @@ export function getAdoptedStyleSheet(location) {
   );
 }
 
-export function rejectImports(contents) {
-  const imports = contents.match(importPattern, '') || [];
+export function rejectImports(contents = '') {
+  const imports = contents.match(importPattern) || [];
   let sheetContent = contents;
   if (imports.length) {
     console.warn(

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,7 @@
-import {adoptedSheetsRegistry, frame, OldCSSStyleSheet} from './shared';
+import {adoptedSheetsRegistry} from './shared';
+import {instanceOfStyleSheet} from './ConstructStyleSheet';
 
 const importPattern = /@import\surl(.*?);/gi;
-
-export function instanceOfStyleSheet(instance) {
-  return (
-    instance instanceof OldCSSStyleSheet ||
-    instance instanceof frame.CSSStyleSheet
-  );
-}
 
 export function checkAndPrepare(sheets, container) {
   const locationType = container === document ? 'Document' : 'ShadowRoot';

--- a/test/polyfill.test.js
+++ b/test/polyfill.test.js
@@ -58,9 +58,8 @@ describe('Constructible Style Sheets polyfill', () => {
 
         const resolved = await result;
 
-        // Equal because polyfill cannot return the same CSSStyleSheet object
-        // since it is immutable.
-        expect(resolved).toEqual(sheet);
+        // Use toBe because there should be referential integrity
+        expect(resolved).toBe(sheet);
       });
 
       it('has a rule set', async () => {
@@ -91,9 +90,8 @@ describe('Constructible Style Sheets polyfill', () => {
       });
 
       it('returns a CSSStyleSheet object itself', () => {
-        // Equal because polyfill cannot return the same CSSStyleSheet object
-        // since it is immutable.
-        expect(result).toEqual(sheet);
+        // Use toBe because there should be referential integrity
+        expect(result).toBe(sheet);
       });
 
       it('has a rule set', async () => {

--- a/test/polyfill.test.js
+++ b/test/polyfill.test.js
@@ -32,8 +32,12 @@ describe('Constructible Style Sheets polyfill', () => {
       expect(sheet.replaceSync).toBeDefined();
     });
 
-    it('passes instanceof check', () => {
+    it('passes instanceof checks', () => {
       expect(sheet instanceof CSSStyleSheet).toBeTruthy();
+
+      const style = document.createElement('style');
+      document.body.append(style);
+      expect(style.sheet instanceof CSSStyleSheet).toBeTruthy();
     });
 
     it('allows overriding the CSSStyleSheet prototype methods', () => {
@@ -71,7 +75,7 @@ describe('Constructible Style Sheets polyfill', () => {
         await globalStyle.sheet
           .replace('.only-test { color: blue; }')
           .catch(error => {
-            expect(error.message).toBe(
+            expect(error.message).toContain(
               "Can't call replace on non-constructed CSSStyleSheets.",
             );
           });
@@ -112,8 +116,8 @@ describe('Constructible Style Sheets polyfill', () => {
         try {
           globalStyle.sheet.replaceSync('.only-test { color: blue; }');
         } catch (error) {
-          expect(error.message).toBe(
-            "Failed to execute 'replaceSync' on 'CSSStyleSheet': Can't call replaceSync on non-constructed CSSStyleSheets.",
+          expect(error.message).toContain(
+            "Can't call replaceSync on non-constructed CSSStyleSheets.",
           );
         }
       });

--- a/test/test.js
+++ b/test/test.js
@@ -10,10 +10,10 @@ headingStyles.replace(` h1 {
 });
 
 paragraphStyles.replaceSync(`p {
-  color: #1121212;
+  color: #ab2121;
   font-family: "Operator Mono", "Helvetica Neue";
 }`);
 
 setTimeout(() => {
-  headingStyles.addRule('*', 'font-family: Helvetica');
+  headingStyles.addRule('*', 'font-family: monospace');
 }, 1000);


### PR DESCRIPTION
Here's my initial go at it. This does the following:
- ensures that the sheet returned by `replace` and `replaceSync` point to the same sheet constructed with `new CSSStyleSheet`
- no longer overwrites the browser default `CSSStyleSheet.prototype` methods, which is always a good thing IMO.
- implements `replace` and `replaceSync` on "non-constructed" stylesheets to match Chrome's behavior.
- all tests pass

Closes #45 