### PR TITLE
fix: abort mutation callback if document doesn't exist anymore

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -2,6 +2,10 @@ import {adoptStyleSheets} from './adopt';
 import {hasShadyCss, locationRegistry, observerRegistry} from './shared';
 
 function adoptAndRestoreStylesOnMutationCallback(mutations) {
+  if (!document) {
+    return;
+  }
+  
   for (let i = 0, len = mutations.length; i < len; i++) {
     const {addedNodes, removedNodes} = mutations[i];
 


### PR DESCRIPTION
When using the polyfill in a create-react-app setup with jest and jsdom where the polyfill is injected via `setupTests.ts` the tests work as expected but an exception occurs after the tests have finished.

```
Error: Uncaught [TypeError: Cannot read property 'createDocumentFragment' of null]
    at reportException (/SOME_PATH/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:62:24)
    at notifyMutationObservers (/SOME_PATH/node_modules/jsdom/lib/jsdom/living/helpers/mutation-observers.js:166:11)
    at /SOME_PATH/node_modules/jsdom/lib/jsdom/living/helpers/mutation-observers.js:133:5 TypeError: Cannot read property 'createDocumentFragment' of null
    at adoptStyleSheets (/SOME_PATH/node_modules/construct-style-sheets-polyfill/dist/adoptedStyleSheets.js:150:30)
    at MutationObserverImpl.adoptAndRestoreStylesOnMutationCallback [as _callback] (/SOME_PATH/node_modules/construct-style-sheets-polyfill/dist/adoptedStyleSheets.js:223:11)
    at notifyMutationObservers (/SOME_PATH/node_modules/jsdom/lib/jsdom/living/helpers/mutation-observers.js:158:14)
    at /SOME_PATH/node_modules/jsdom/lib/jsdom/living/helpers/mutation-observers.js:133:5

    at VirtualConsole.<anonymous> (node_modules/jsdom/lib/jsdom/virtual-console.js:29:45)
    at reportException (node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:28)
    at notifyMutationObservers (node_modules/jsdom/lib/jsdom/living/helpers/mutation-observers.js:166:11)
    at node_modules/jsdom/lib/jsdom/living/helpers/mutation-observers.js:133:5
```

It looks like the MutationOberver's callback is executed after the document is gone.

```
construct-style-sheets-polyfill@^2.4.2
react-scripts@4.0.0
jest@26.6.0
jsdom@^16.4.0
typescript@~4.0.5
node: v12.18.2
yarn: 1.22.10
```