### PR TITLE
Add declare module to typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+declare module 'construct-style-sheets-polyfill';
+
 interface CSSStyleSheet {
   replace(text: string): Promise<CSSStyleSheet>;
   replaceSync(text: string): void;


### PR DESCRIPTION
Typescript shows this error when importing:

```
File '<project>/node_modules/construct-style-sheets-polyfill/dist/adoptedStyleSheets.d.ts' is not a module.
```

This PR fixes that error.

As a workaround, you can use:

`construct-style-sheets-polyfill.d.ts`
```ts
declare module 'construct-style-sheets-polyfill';
```