### PR TITLE
chore: set type to module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/adoptedStyleSheets.js",
   "module": "dist/adoptedStyleSheets.js",
   "types": "dist/adoptedStyleSheets.d.ts",
+  "type": "module",
   "files": [
     "dist/adoptedStyleSheets.js",
     "dist/adoptedStyleSheets.d.ts"


### PR DESCRIPTION
The `type` property of `package.json` may be used by frontend tooling (e.g Webpack, Vite) in determining whether the package's entry point is a conventional CJS or ES module. If no property is specified, the entry point may be treated as a CJS module. As an illustration, here is a warning that Vite shows when you import the construct-style-sheets polyfill:

> construct-style-sheets-polyfill doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.

This PR explicitly sets the `type` property to `module` to avoid possible misinterpretation.

Related to https://github.com/vaadin/flow/issues/12574
