### PR TITLE
fix: change document check to avoid reference error

### DIFF
--- a/src/Location.ts
+++ b/src/Location.ts
@@ -216,7 +216,7 @@ function Location(this: Location, element: Document | ShadowRoot) {
     new MutationObserver((mutations, observer) => {
       // Workaround for
       // https://github.com/calebdwilliams/construct-style-sheets/pull/63
-      if (!document) {
+      if (typeof document === 'undefined') {
         observer.disconnect();
         return;
       }


### PR DESCRIPTION
Seems like the mutation callback gets executed after the document is gone in vitest which causes following error:
`Error: Uncaught [ReferenceError: document is not defined]`

```diff
- if (!document) {
+ if (typeof document === 'undefined') {
```

By changing the condition like this the check should work as intended.